### PR TITLE
Add a hard quota for disk usage in percent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parking_lot = "0.12.1"
 crc32c = "0.6.3"
 flume = "0.10.14"
 tracing = { version = "0.1.36", optional = true }
-file-manager = { git = "https://github.com/khonsulabs/file-manager", branch = "main" }
+file-manager = { git = "https://github.com/spaceandtimelabs/file-manager", branch = "main" }
 log = "0.4.19"
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,9 @@ pub struct Configuration<M> {
     /// was to allow detection of what format or version of a format the data
     /// was inside of the log without needing to parse the entries.
     pub version_info: Arc<Vec<u8>>,
+    /// The maximum disk usage, in percent, before writes start to be rejected.
+    /// Must be a value between 0 and 100.
+    pub max_disk_usage_percent: u16,
 }
 
 impl Default for Configuration<StdFileManager> {
@@ -72,6 +75,7 @@ where
             checkpoint_after_bytes: kilobytes(768),
             buffer_bytes: kilobytes(16),
             version_info: Arc::default(),
+            max_disk_usage_percent: 95,
         }
     }
     /// Sets the number of bytes to preallocate for each segment file. Returns `self`.

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,7 +1,7 @@
-use std::io::{self, Read, Write};
 use crc32c::crc32c_append;
 use file_manager::FileManager;
 use parking_lot::MutexGuard;
+use std::io::{self, Read, Write};
 
 use crate::{
     log_file::{LogFile, LogFileWriter},
@@ -79,7 +79,8 @@ where
         let new_length = self.commit_internal(|_file| Ok(()))?;
         let id = self.id;
         let file = self.file.take().expect("Already committed");
-        self.log.reclaim(file, WriteResult::Entry { new_length }, true)?;
+        self.log
+            .reclaim(file, WriteResult::Entry { new_length }, true)?;
         Ok(id)
     }
 
@@ -100,7 +101,8 @@ where
         let new_length = self.commit_internal(callback)?;
         let id = self.id;
         let file = self.file.take().expect("file already dropped");
-        self.log.reclaim(file, WriteResult::Entry { new_length }, false)?;
+        self.log
+            .reclaim(file, WriteResult::Entry { new_length }, false)?;
         Ok(id)
     }
 
@@ -117,7 +119,9 @@ where
         let mut writer = file.lock();
         writer.revert_to(self.original_length)?;
         drop(writer);
-        self.log.reclaim(file, WriteResult::RolledBack, false).unwrap();
+        self.log
+            .reclaim(file, WriteResult::RolledBack, false)
+            .unwrap();
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,20 @@ where
     /// This call will acquire an exclusive lock to the active file or block
     /// until it can be acquired.
     pub fn begin_entry(&self) -> io::Result<EntryWriter<'_, M>> {
+        // Check if we're below the available space limit, otherwise refuse to allow
+        // to begin the entry. This doesn't mean we couldn't actually write the entry
+        // since the WAL files are pre-allocated, but it could mean that the
+        // checkpointing thread either failed or would fail for lack of space, so it's
+        // better to refuse transactions to gitve an opportunity to delete files.
+        if !is_enough_space_available(&self.data.config)? {
+            error!("Not enough space available to append to WAL! Available space (bytes): {:?}. Total space (bytes): {:?}",
+                   available_space_bytes(&self.data.config)?, total_space_bytes(&self.data.config)?);
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "Storage is full",
+            ));
+        }
+
         let mut files = self.data.files.lock();
         let file = loop {
             if let Some(file) = files.active.take() {
@@ -543,6 +557,21 @@ where
     }
 }
 
+fn available_space_bytes<M: FileManager>(config: &Configuration<M>) -> io::Result<u64> {
+    config.file_manager.available_space_bytes(&config.directory)
+}
+
+fn total_space_bytes<M: FileManager>(config: &Configuration<M>) -> io::Result<u64> {
+    config.file_manager.total_space_bytes(&config.directory)
+}
+
+fn is_enough_space_available<M: FileManager>(config: &Configuration<M>) -> io::Result<bool> {
+    let available_space_percent =
+        u16::try_from(available_space_bytes(config)? * 100 / total_space_bytes(config)?)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(available_space_percent <= config.max_disk_usage_percent)
+}
+
 enum CheckpointCommand<F>
 where
     F: file_manager::File,
@@ -579,6 +608,14 @@ where
             self.all.insert(next_id, all_entry);
             file
         } else {
+            if !is_enough_space_available(config)? {
+                error!("Not enough space available activate new file! Available space (bytes): {:?}. Total space (bytes): {:?}",
+                   available_space_bytes(config)?, total_space_bytes(config)?);
+                return Err(io::Error::new(
+                    io::ErrorKind::OutOfMemory,
+                    "Storage is full",
+                ));
+            }
             let file = LogFile::write(
                 next_id,
                 config.directory.join(file_name).into(),


### PR DESCRIPTION
This adds a hard disk quota for disk usage in percent, after which:
- New entries will be rejected
- Activating new files will fail

The default quota is 95%.